### PR TITLE
fix: RSS-GRAPHI-2_05 fix vitest to handle tsconfig path aliases

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -10,6 +11,11 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       exclude: [...coverageConfigDefaults.exclude, './src/interfaces/**', './next.config.mjs'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
     },
   },
 });


### PR DESCRIPTION
### What type of PR is this?

_Select all that apply_

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Tests
- [ ] Documentation
- [x] Other

---

### Issue link

[Issue link](https://github.com/Wood85/graphiql-app/issues/31)

---

### Description

Add configuration for Vitest to handle path aliases defined in tsconfig.json

---

### Screenshots and recordings

![image](https://github.com/user-attachments/assets/df897b40-7e7f-4ed3-8d66-e20702a7f439)

---

### Did you have merge conflicts?

_This information needs to check, if the previous merged features still work correctly_

- [ ] Yes
- [x] No

---

