### PR TITLE
style: RSS-GRAPHI-3_06: Remove borders of the Button component

### DIFF
--- a/src/components/UI/Button/Button.module.scss
+++ b/src/components/UI/Button/Button.module.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   align-items: center;
   gap: 8px;
-  border: 1px solid $blue;
+  border: none;
   border-radius: 4px;
 
   color: $white;


### PR DESCRIPTION
### What type of PR is this?

_Select all that apply_

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Tests
- [ ] Documentation
- [x] Other

---

### Issue link

[Issue link](https://github.com/Wood85/graphiql-app/issues/45)

---

### Description

The borders of the Button component were removed: the `border` property was set to `none`

---

### Screenshots and recordings

Before:
![image](https://github.com/user-attachments/assets/f55c14af-52e5-44af-a352-c1003b8f8cd2)

After:
![image](https://github.com/user-attachments/assets/e17e1763-52ce-4187-bdc0-c9175a6db2f5)

---

### Did you have merge conflicts?

_This information needs to check, if the previous merged features still work correctly_

- [ ] Yes
- [x] No

---
