### PR TITLE
fix: RSS-GRAPHI-7_01: Fix History

### DIFF
--- a/src/__tests__/GraphiQLClient.test.tsx
+++ b/src/__tests__/GraphiQLClient.test.tsx
@@ -24,7 +24,6 @@ describe('GraphiQLClient', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Loading...')).toBeInTheDocument();
       expect(getByText('Set')).toBeInTheDocument();
       expect(getByText('Send')).toBeInTheDocument();
       expect(getByText('No schema available')).toBeInTheDocument();

--- a/src/app/[locale]/components/RESTAPIClient/BodyEditor/BodyEditor.tsx
+++ b/src/app/[locale]/components/RESTAPIClient/BodyEditor/BodyEditor.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { useState } from 'react';
 
 import Editor from '@monaco-editor/react';
 
-import { replaceInHistory } from '@/utils/replaceHistory';
 import Button from '@/components/UI/Button/Button';
+import { replaceInHistory } from '@/utils/replaceHistory';
 import HeadersEditor from '../HeadersEditor/HeadersEditor';
 import VariablesEditor from '../VariablesEditor/VariablesEditor';
 
@@ -14,6 +14,7 @@ import styles from './BodyEditor.module.scss';
 
 interface IProps {
   setBody: React.Dispatch<React.SetStateAction<string>>;
+  body: string;
 }
 
 type TSelect = 'headers' | 'body' | 'variables';
@@ -22,7 +23,7 @@ type TFormat = 'json' | 'text';
 
 export const dynamic = 'force-dynamic';
 
-function BodyEditor({ setBody }: IProps): JSX.Element {
+function BodyEditor({ setBody, body }: IProps): JSX.Element {
   const t = useTranslations('Restapi');
 
   const [select, setSelect] = useState<TSelect>('headers');
@@ -96,7 +97,7 @@ function BodyEditor({ setBody }: IProps): JSX.Element {
             defaultValue='{}'
             language={format}
             theme='vs-light'
-            value={editorValue}
+            value={body ?? editorValue}
             options={{
               detectIndentation: false,
               fontFamily: '"Cera Pro"',

--- a/src/app/[locale]/components/RESTAPIClient/RESTAPIClient.tsx
+++ b/src/app/[locale]/components/RESTAPIClient/RESTAPIClient.tsx
@@ -2,15 +2,15 @@
 
 import { useEffect, useState } from 'react';
 
+import { Response } from '@/components/Response/Response';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
-import { type IRequestLS } from '@/interfaces/LocalStorage';
+import useHeaders from '@/hooks/useHeaders';
+import { type IHeadersVariables, type IRequestLS } from '@/interfaces/LocalStorage';
 import { TRequestMethod } from '@/interfaces/RequestMethod';
 import type { IResponse } from '@/interfaces/Response';
-import { headers, variables } from '@/store/reducers/restFullSlice';
 import { loadingFinished, loadingStarted } from '@/store/reducers/loadingStateSlice';
+import { headers, variables } from '@/store/reducers/restFullSlice';
 import { replaceInHistory } from '@/utils/replaceHistory';
-import useHeaders from '@/hooks/useHeaders';
-import { Response } from '@/components/Response/Response';
 import { BodyEditor } from './BodyEditor/BodyEditor';
 import { RequestControl } from './RequestControl/RequestControl';
 
@@ -84,8 +84,8 @@ export default function RESTAPIClient(): JSX.Element {
     }
 
     const allRequests = [];
-    if (localStorage.getItem('RESTFUL_request') !== null) {
-      JSON.parse(localStorage.getItem('RESTFUL_request') ?? '').forEach((el: IRequestLS) => allRequests.push(el));
+    if (localStorage.getItem('history_requests') !== null) {
+      JSON.parse(localStorage.getItem('history_requests') ?? '').forEach((el: IRequestLS) => allRequests.push(el));
     }
     const currentTime = new Date().getTime();
     const currentData = {
@@ -99,16 +99,12 @@ export default function RESTAPIClient(): JSX.Element {
     };
     allRequests.push(currentData);
 
-    localStorage.setItem('RESTFUL_request', JSON.stringify(allRequests));
+    localStorage.setItem('history_requests', JSON.stringify(allRequests));
   };
 
   useEffect(() => {
-    const match = window.location.search.match(/\?history=[0-9]+/gm);
-
-    if (match !== null) {
-      const historyRequest = match?.toString().replace('?history=', '');
-      const data = JSON.parse(localStorage.getItem('RESTFUL_request') ?? '');
-      const currentData = data.filter((el: IRequestLS) => el.time.toString() === historyRequest)[0] as IRequestLS;
+    if (localStorage.getItem('current_request') !== null) {
+      const currentData = JSON.parse(localStorage.getItem('current_request') ?? '') as IRequestLS;
 
       setUrl(currentData.url);
 
@@ -139,8 +135,9 @@ export default function RESTAPIClient(): JSX.Element {
           break;
       }
       setBody(currentData.body);
-      dispatcher(variables(currentData.variables));
       dispatcher(headers(currentData.headers));
+      dispatcher(variables(currentData.variables as IHeadersVariables[]));
+      localStorage.removeItem('current_request');
     }
   }, [dispatcher]);
 
@@ -148,7 +145,7 @@ export default function RESTAPIClient(): JSX.Element {
     <div className={style.container}>
       <form className={style.form} onSubmit={handleSubmit}>
         <RequestControl method={method} setMethod={setMethod} url={url} setUrl={setUrl} body={body} />
-        <BodyEditor setBody={setBody} />
+        <BodyEditor setBody={setBody} body={body} />
       </form>
       {response?.status != null && <Response response={response} method={method} />}
     </div>

--- a/src/app/[locale]/components/RESTAPIClient/RESTAPIClient.tsx
+++ b/src/app/[locale]/components/RESTAPIClient/RESTAPIClient.tsx
@@ -39,6 +39,9 @@ export default function RESTAPIClient(): JSX.Element {
 
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
+    replaceInHistory('method', method);
+    replaceInHistory('url', url);
+    replaceInHistory('body', body);
     const { href } = window.location;
     const apiUrl = href.replace(/\/restapi\/|\/graphiql\//g, '/api/');
     dispatcher(loadingStarted());
@@ -107,32 +110,8 @@ export default function RESTAPIClient(): JSX.Element {
       const currentData = JSON.parse(localStorage.getItem('current_request') ?? '') as IRequestLS;
 
       setUrl(currentData.url);
-
-      switch (currentData.method) {
-        case TRequestMethod.GET:
-          setMethod(TRequestMethod.GET);
-          break;
-        case TRequestMethod.POST:
-          setMethod(TRequestMethod.POST);
-          break;
-        case TRequestMethod.PUT:
-          setMethod(TRequestMethod.PUT);
-          break;
-        case TRequestMethod.PATCH:
-          setMethod(TRequestMethod.PATCH);
-          break;
-        case TRequestMethod.DELETE:
-          setMethod(TRequestMethod.DELETE);
-          break;
-        case TRequestMethod.HEAD:
-          setMethod(TRequestMethod.HEAD);
-          break;
-        case TRequestMethod.OPTIONS:
-          setMethod(TRequestMethod.OPTIONS);
-          break;
-
-        default:
-          break;
+      if ((currentData.method as TRequestMethod) in TRequestMethod) {
+        setMethod(currentData.method as TRequestMethod);
       }
       setBody(currentData.body);
       dispatcher(headers(currentData.headers));

--- a/src/app/[locale]/history/page.tsx
+++ b/src/app/[locale]/history/page.tsx
@@ -15,11 +15,16 @@ function History(): JSX.Element {
   const [restfulRequest, setRestfulRequest] = useState<IRequestLS[] | ''>('');
 
   useEffect(() => {
-    if (localStorage.getItem('RESTFUL_request') !== null) {
-      const value = JSON.parse(localStorage.getItem('RESTFUL_request') ?? '') as IRequestLS[];
+    if (localStorage.getItem('history_requests') !== null) {
+      const value = JSON.parse(localStorage.getItem('history_requests') ?? '') as IRequestLS[];
       setRestfulRequest(value);
     }
   }, []);
+  const saveCurrentRequest = (el: IRequestLS): void => {
+    if (localStorage.getItem('history_requests') !== null) {
+      localStorage.setItem('current_request', JSON.stringify(el));
+    }
+  };
 
   return (
     <ProtectedRouteWrapper>
@@ -32,7 +37,13 @@ function History(): JSX.Element {
                 {restfulRequest.map((el) => (
                   <div key={el.time} className={style.history_request}>
                     <div className={style.method}>{el.method}</div>
-                    <Link href={`/${el.client}?history=${el.time}`} className={style.link}>
+                    <Link
+                      href={`/${el.client}`}
+                      className={style.link}
+                      onClick={() => {
+                        saveCurrentRequest(el);
+                      }}
+                    >
                       {el.url}
                     </Link>
                   </div>

--- a/src/components/GraphiQLClient/GraphiQLClient.tsx
+++ b/src/components/GraphiQLClient/GraphiQLClient.tsx
@@ -66,7 +66,7 @@ export default function GraphiQLClient({ graphqlDocsIsOpen, setIsDocsAvailable }
 
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
-
+    replaceInHistory('url', url);
     const { href } = window.location;
     const apiUrl = href.replace(/\/restapi\/|\/graphiql\//g, '/api/');
     dispatcher(loadingStarted());

--- a/src/components/GraphiQLClient/GraphiQLClient.tsx
+++ b/src/components/GraphiQLClient/GraphiQLClient.tsx
@@ -7,13 +7,21 @@ import { type IntrospectionQuery } from 'graphql';
 
 import SelectArrowBottomIcon from '@/assets/images/icons/SelectArrowBottomIcon';
 import SelectArrowTopIcon from '@/assets/images/icons/SelectArrowTopIcon';
+import { useAppDispatch, useAppSelector } from '@/hooks/redux';
+import useHeaders from '@/hooks/useHeaders';
+import { type IRequestLS } from '@/interfaces/LocalStorage';
 import { TRequestMethod } from '@/interfaces/RequestMethod';
 import type { IResponse } from '@/interfaces/Response';
+import {
+  gqlHeaders,
+  selectGraphQLHeaders,
+  selectGraphQLVariables,
+  setGraphQLVariables,
+  type TGraphQLVars,
+} from '@/store/reducers/graphqlSlice';
 import { loadingFinished, loadingStarted } from '@/store/reducers/loadingStateSlice';
-import { useAppDispatch } from '@/hooks/redux';
-import { replaceInHistory } from '@/utils/replaceHistory';
-import useHeaders from '@/hooks/useHeaders';
 import { GRAPHQL } from '@/utils/constants';
+import { replaceInHistory } from '@/utils/replaceHistory';
 import { Response } from '../Response/Response';
 import Button from '../UI/Button/Button';
 import { Docs } from './Docs/Docs';
@@ -37,13 +45,16 @@ enum TTabs {
 export default function GraphiQLClient({ graphqlDocsIsOpen, setIsDocsAvailable }: IProps): JSX.Element {
   const [url, setUrl] = useState('');
   const [sdlUrl, setSdlUrl] = useState('');
+  const [queryFromLS, setQueryFromLS] = useState('#Query Editor');
   const [docs, setDocs] = useState<IntrospectionQuery | null>(null);
   const [response, setResponse] = useState<IResponse | null>(null);
   const [activeTab, setActiveTab] = useState<TTabs>(TTabs.VARIABLES);
-  const [isOptionsOpen, setIsOptionsOpen] = useState(false);
+  const [isOptionsOpen, setIsOptionsOpen] = useState(true);
 
   const dispatcher = useAppDispatch();
   const headers = useHeaders('graphql');
+  const variablesSelector = useAppSelector(selectGraphQLVariables);
+  const graphqlHeadersSelector = useAppSelector(selectGraphQLHeaders);
 
   useEffect(() => {
     replaceInHistory('method', GRAPHQL);
@@ -84,7 +95,39 @@ export default function GraphiQLClient({ graphqlDocsIsOpen, setIsDocsAvailable }
     } finally {
       dispatcher(loadingFinished());
     }
+
+    const allRequests = [];
+    if (localStorage.getItem('history_requests') !== null) {
+      JSON.parse(localStorage.getItem('history_requests') ?? '').forEach((el: IRequestLS) => allRequests.push(el));
+    }
+    const currentTime = new Date().getTime();
+    const currentData = {
+      client: 'graphiql',
+      time: currentTime,
+      method: GRAPHQL,
+      url,
+      sdlUrl,
+      headers: graphqlHeadersSelector,
+      body: queryFromLS,
+      variables: variablesSelector,
+    };
+    allRequests.push(currentData);
+
+    localStorage.setItem('history_requests', JSON.stringify(allRequests));
   };
+
+  useEffect(() => {
+    if (localStorage.getItem('current_request') !== null) {
+      const currentData = JSON.parse(localStorage.getItem('current_request') ?? '') as IRequestLS;
+
+      setUrl(currentData.url ?? '');
+      setSdlUrl(currentData.sdlUrl ?? '');
+      setQueryFromLS(currentData.body);
+      dispatcher(gqlHeaders(currentData.headers ?? []));
+      dispatcher(setGraphQLVariables(currentData.variables as TGraphQLVars));
+      localStorage.removeItem('current_request');
+    }
+  }, [dispatcher]);
 
   return (
     <div className={style.wrapper}>
@@ -100,7 +143,7 @@ export default function GraphiQLClient({ graphqlDocsIsOpen, setIsDocsAvailable }
               setDocs={setDocs}
               setIsDocsAvailable={setIsDocsAvailable}
             />
-            <QueryEditor />
+            <QueryEditor setQueryFromLS={setQueryFromLS} queryFromLS={queryFromLS} />
             <div className={style.options}>
               <div className={style.tabs_line}>
                 <div className={style.tabs}>

--- a/src/interfaces/LocalStorage.ts
+++ b/src/interfaces/LocalStorage.ts
@@ -1,11 +1,14 @@
+import { type TGraphQLVars } from '@/store/reducers/graphqlSlice';
+
 export interface IRequestLS {
   client: string;
   time: number;
   method: string;
   url: string;
+  sdlUrl?: string;
   headers: IHeadersVariables[];
   body: string;
-  variables: IHeadersVariables[];
+  variables: IHeadersVariables[] | TGraphQLVars;
 }
 
 export interface IHeadersVariables {

--- a/src/store/reducers/graphqlSlice.ts
+++ b/src/store/reducers/graphqlSlice.ts
@@ -1,6 +1,6 @@
+import type TRows from '@/interfaces/Rows';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type TRows from '@/interfaces/Rows';
 
 export type TGraphQLVars = Record<string, string | number | boolean | object | undefined>;
 export interface IState {
@@ -47,11 +47,12 @@ export const graphqlSlice = createSlice({
   selectors: {
     selectGraphQLVariables: (state) => state.variables,
     selectVariableNotFound: (state) => state.variableNotFound,
+    selectGraphQLHeaders: (state) => state.headers,
   },
 });
 
 export const { gqlHeaders, gqlFocusCellKey, gqlFocusCellValue, setGraphQLVariables, setVariableNotFound } =
   graphqlSlice.actions;
-export const { selectGraphQLVariables, selectVariableNotFound } = graphqlSlice.selectors;
+export const { selectGraphQLVariables, selectVariableNotFound, selectGraphQLHeaders } = graphqlSlice.selectors;
 
 export default graphqlSlice.reducer;


### PR DESCRIPTION
### What type of PR is this? 


- [x] New Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Tests
- [ ] Documentation Update
- [ ] Other
  
---

### Issue link

https://github.com/users/Wood85/projects/1/views/1?pane=issue&itemId=79359837

---

### Description


- History section should display request using links, on clicking on the link, user should be navigated to the respective section (RESTfull client or GraphiQL).
- History section should show requests sorted by the time of their execution.
- If there are no requests in the local storage, show message to the user, e.g. "You haven't executed any requests yet", "It's empty here. Try those options:" and give links to the RESTfull and to the GraphiQL clients.

---

### Screenshots and recordings

![image](https://github.com/user-attachments/assets/2c190b05-ccbc-4100-baee-ecf296ba8e9d)

![image](https://github.com/user-attachments/assets/11dfb876-1052-43c0-9218-477d383002bd)

---

### Did you have merge conflicts?

- [ ] Yes
- [x] No

---

### Other information

none